### PR TITLE
Fixed line-breaks missing

### DIFF
--- a/site/main.js
+++ b/site/main.js
@@ -7,9 +7,9 @@ const updateOutput = evt => {
 	const data = evt.target.value;
 
 	if (data) {
-		outputEl.innerText = swiftvg(evt.target.value).join("\n");
+		outputEl.value = swiftvg(evt.target.value).join("\n");
 	} else {
-		outputEl.innerText = "";
+		outputEl.value = "";
 	}
 };
 


### PR DESCRIPTION
Hi Mike, it appears that the current version is missing line breaks after conversion. I am attempting to change `innerText` to `value`, and this seems to be working well.

Here is a sample test.

```
<svg width="26" height="7" viewBox="0 0 26 7" fill="none" xmlns="http://www.w3.org/2000/svg">
<path d="M26 3V0H0V3H6.45454C7.74219 3 8.95469 3.60625 9.72727 4.63636C11.3636 6.81818 14.6364 6.81818 16.2727 4.63636C17.0453 3.60625 18.2578 3 19.5455 3H26Z" fill="#D9D9D9"/>
</svg>
```